### PR TITLE
fix object nesting issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -562,7 +562,7 @@ IoRedisSessions = (function(superClass) {
         }
         o = [];
         for (j = 0, len = resp.length; j < len; j++) {
-          e = resp[j];
+          e = resp[j][1];
           session = _this._prepareSession(e);
           if (session !== null) {
             o.push(session);


### PR DESCRIPTION
After switching to ioredis my soid calls stopped working as the returned session objects appear to be nested a level deeper.